### PR TITLE
Fix farm APR reward calculation

### DIFF
--- a/lib/ui/views/util/components/dex_apr_value.dart
+++ b/lib/ui/views/util/components/dex_apr_value.dart
@@ -29,16 +29,14 @@ class DEXAprValue {
         final now =
             (DateTime.now().toUtc().millisecondsSinceEpoch / 1000).truncate();
 
-        if (remainingRewardInFiat > 0 && now < endDate) {
+        if (remainingRewardInFiat > 0 && data.value > 0 && now < endDate) {
           // 31 536 000 second in a year
           final rewardScalledToYear =
-              remainingRewardInFiat * ((endDate - now) / 31536000);
-          var apr = 0.0;
-          if (data.value > 0) {
-            apr = (Decimal.parse('$rewardScalledToYear') /
-                    Decimal.parse('${data.value}'))
-                .toDouble();
-          }
+              remainingRewardInFiat * (31536000 / (endDate - now));
+
+          final apr = (Decimal.parse('$rewardScalledToYear') /
+                  Decimal.parse('${data.value}'))
+              .toDouble();
 
           return '${(apr * 100).formatNumber(precision: 4)}%';
         }


### PR DESCRIPTION
Reworked farm APR calculation.
Before it was displaying the APR as if the reward were send over 1 year. But it is possible that all the reward are sent in less than 1 year. So it was strange to have an APR for a year while you get all the reward in less time.
Now the APR is calculated for the period of the farm and reported to a year. It is more accurate regarding the reward earned each second.

Before: 
![image](https://github.com/archethic-foundation/dex/assets/26260538/fa4c6bfd-716a-43c5-806c-81145d3d2990)

After: 
![image](https://github.com/archethic-foundation/dex/assets/26260538/7f27e034-4aed-42b7-ba30-3e84095be368)
