### PR TITLE
Integrate multisig

### DIFF
--- a/contracts/commands/contract_management/deploy_router.js
+++ b/contracts/commands/contract_management/deploy_router.js
@@ -1,6 +1,6 @@
 import Archethic, { Utils } from "@archethicjs/sdk"
 import config from "../../config.js"
-import { getRouterCode, getServiceGenesisAddress, sendTransactionWithFunding } from "../utils.js"
+import { getRouterCode, getServiceGenesisAddress, sendTransactionWithFunding, sendTransactionWithoutFunding } from "../utils.js"
 
 const command = "deploy_router"
 const describe = "Deploy the router"
@@ -14,6 +14,12 @@ const builder = {
     describe: "The environment config to use (default to local)",
     demandOption: false,
     type: "string"
+  },
+  without_funding: {
+    describe: "Determines if the funding must be disabled",
+    demandOption: false,
+    type: "boolean",
+    default: false
   }
 }
 
@@ -61,9 +67,16 @@ const handler = async function(argv) {
 
   routerTx = keychain.buildTransaction(routerTx, "Router", index).originSign(Utils.originPrivateKey)
 
-  sendTransactionWithFunding(routerTx, keychain, archethic)
-    .then(() => process.exit(0))
-    .catch(() => process.exit(1))
+  if (argv["without_funding"]) {
+    sendTransactionWithoutFunding(routerTx, archethic)
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1))
+  }
+  else {
+    sendTransactionWithFunding(routerTx, keychain, archethic)
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1))
+  }
 }
 
 export default {

--- a/contracts/commands/contract_management/get_router_address.js
+++ b/contracts/commands/contract_management/get_router_address.js
@@ -1,0 +1,54 @@
+import Archethic from "@archethicjs/sdk"
+import config from "../../config.js"
+import {
+  getServiceGenesisAddress,
+} from "../utils.js"
+
+const command = "get_router_address"
+const describe = "Get router address"
+const builder = {
+  access_seed: {
+    describe: "The Keychain access seed (default in env config)",
+    demandOption: false,
+    type: "string"
+  },
+  env: {
+    describe: "The environment config to use (default to local)",
+    demandOption: false,
+    type: "string"
+  }
+}
+
+const handler = async function(argv) {
+  const envName = argv["env"] ? argv["env"] : "local"
+  const env = config.environments[envName]
+
+  const keychainAccessSeed = argv["access_seed"] ? argv["access_seed"] : env.keychainAccessSeed
+
+  if (keychainAccessSeed == undefined) {
+    console.log("Keychain access seed not defined")
+    process.exit(1)
+  }
+
+  const archethic = new Archethic(env.endpoint)
+  await archethic.connect()
+
+  let keychain
+
+  try {
+    keychain = await archethic.account.getKeychain(keychainAccessSeed)
+  } catch (err) {
+    console.log(err)
+    process.exit(1)
+  }
+
+  const routerGenesisAddress = getServiceGenesisAddress(keychain, "Router")
+  console.log("Router address:", routerGenesisAddress)
+}
+
+export default {
+  command,
+  describe,
+  builder,
+  handler
+}

--- a/contracts/commands/contract_management/update_farm_dates.js
+++ b/contracts/commands/contract_management/update_farm_dates.js
@@ -1,6 +1,7 @@
 import Archethic, { Utils } from "@archethicjs/sdk"
 import config from "../../config.js"
-import { getServiceGenesisAddress } from "../utils.js"
+import { getServiceGenesisAddress, sendWithWallet } from "../utils.js"
+import { getProposeTransaction } from "@archethicjs/multisig-sdk"
 
 const command = "update_farm_dates"
 const describe = "Update the start and end date of a farm"
@@ -29,7 +30,13 @@ const builder = {
     describe: "The environment config to use (default to local)",
     demandOption: false,
     type: "string"
-  }
+  },
+  with_multisig: {
+    describe: "Determines if the master is using a multisig",
+    demandOption: false,
+    type: "boolean",
+    default: false
+  },
 }
 
 const handler = async function(argv) {
@@ -43,7 +50,10 @@ const handler = async function(argv) {
     process.exit(1)
   }
 
-  const archethic = new Archethic(env.endpoint)
+  const archethic = new Archethic(argv["with_multisig"] ? undefined : env.endpoint)
+  if (archethic.rpcWallet) {
+    archethic.rpcWallet.setOrigin({ name: "Archethic DEX CLI" });
+  }
   await archethic.connect()
 
   let keychain
@@ -62,6 +72,19 @@ const handler = async function(argv) {
   const masterGenesisAddress = getServiceGenesisAddress(keychain, "Master")
   console.log("Master genesis address:", masterGenesisAddress)
   const index = await archethic.transaction.getTransactionIndex(masterGenesisAddress)
+
+  if (argv["with_multisig"]) {
+    const updateTx = getProposeTransaction(archethic, masterGenesisAddress, {
+      recipients: [
+        { address: farmAddress, action: "update_dates", args: [startDate, endDate] }
+      ]
+    })
+    sendWithWallet(updateTx, archethic)
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1))
+
+    return
+  }
 
   let updateTx = archethic.transaction.new()
     .setType("transfer")

--- a/contracts/commands/contract_management/update_farms.js
+++ b/contracts/commands/contract_management/update_farms.js
@@ -1,6 +1,7 @@
 import Archethic, { Utils } from "@archethicjs/sdk"
 import config from "../../config.js"
-import { getServiceGenesisAddress } from "../utils.js"
+import { getServiceGenesisAddress, sendWithWallet } from "../utils.js"
+import { getProposeTransaction } from "@archethicjs/multisig-sdk"
 
 const command = "update_farms"
 const describe = "Update all farm code"
@@ -14,7 +15,13 @@ const builder = {
     describe: "The environment config to use (default to local)",
     demandOption: false,
     type: "string"
-  }
+  },
+  with_multisig: {
+    describe: "Determines if the master is using a multisig",
+    demandOption: false,
+    type: "boolean",
+    default: false
+  },
 }
 
 const handler = async function(argv) {
@@ -28,7 +35,10 @@ const handler = async function(argv) {
     process.exit(1)
   }
 
-  const archethic = new Archethic(env.endpoint)
+  const archethic = new Archethic(argv["with_multisig"] ? undefined : env.endpoint)
+  if (archethic.rpcWallet) {
+    archethic.rpcWallet.setOrigin({ name: "Archethic DEX CLI" });
+  }
   await archethic.connect()
 
   let keychain
@@ -51,6 +61,19 @@ const handler = async function(argv) {
   const masterGenesisAddress = getServiceGenesisAddress(keychain, "Master")
   console.log("Master genesis address:", masterGenesisAddress)
   const index = await archethic.transaction.getTransactionIndex(masterGenesisAddress)
+
+  if (argv["with_multisig"]) {
+    const updateTx = getProposeTransaction(archethic, masterGenesisAddress, {
+      recipients: [
+        { address: routerGenesisAddress, action: "update_farms_code" }
+      ]
+    })
+    sendWithWallet(updateTx, archethic)
+      .then(() => process.exit(0))
+      .catch(() => process.exit(1))
+
+    return
+  }
 
   let updateTx = archethic.transaction.new()
     .setType("transfer")

--- a/contracts/commands/test/deploy_pool.js
+++ b/contracts/commands/test/deploy_pool.js
@@ -139,15 +139,15 @@ const handler = async function (argv) {
   const tx = archethic.transaction.new()
 
   if (token1.address == "UCO") {
-    tx.addUCOTransfer(poolGenesisAddress, Utils.toBigInt(token1.amount))
+    tx.addUCOTransfer(poolGenesisAddress, Utils.parseBigInt(token1.amount.toString()))
   } else {
-    tx.addTokenTransfer(poolGenesisAddress, Utils.toBigInt(token1.amount), token1.address)
+    tx.addTokenTransfer(poolGenesisAddress, Utils.parseBigInt(token1.amount.toString()), token1.address)
   }
 
   if (token2.address == "UCO") {
-    tx.addUCOTransfer(poolGenesisAddress, Utils.toBigInt(token2.amount))
+    tx.addUCOTransfer(poolGenesisAddress, Utils.parseBigInt(token2.amount.toString()))
   } else {
-    tx.addTokenTransfer(poolGenesisAddress, Utils.toBigInt(token2.amount), token2.address)
+    tx.addTokenTransfer(poolGenesisAddress, Utils.parseBigInt(token2.amount.toString()), token2.address)
   }
 
   tx.setType("transfer")

--- a/contracts/dex.js
+++ b/contracts/dex.js
@@ -5,6 +5,7 @@ import { hideBin } from "yargs/helpers";
 
 import init_keychain from "./commands/contract_management/init_keychain.js";
 import deploy_factory from "./commands/contract_management/deploy_factory.js";
+import deploy_multisig from "./commands/contract_management/deploy_multisig.js";
 import deploy_farm_scheduler from "./commands/contract_management/deploy_farm_scheduler.js";
 import deploy_router from "./commands/contract_management/deploy_router.js";
 import update_router from "./commands/contract_management/update_router.js";
@@ -26,12 +27,15 @@ import deposit from "./commands/test/deposit.js";
 import claim from "./commands/test/claim.js";
 import withdraw from "./commands/test/withdraw.js";
 
+import get_router_address from "./commands/contract_management/get_router_address.js";
+
 const y = yargs(hideBin(process.argv));
 
 y.command(init_keychain).help();
 y.command(deploy_factory).help();
 y.command(deploy_farm_scheduler).help();
 y.command(deploy_router).help();
+y.command(deploy_multisig).help();
 y.command(update_router).help();
 y.command(update_pools).help();
 y.command(update_farms).help();
@@ -51,5 +55,7 @@ y.command(deploy_farm).help();
 y.command(deposit).help();
 y.command(claim).help();
 y.command(withdraw).help();
+
+y.command(get_router_address).help()
 
 y.parse();

--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -4,8 +4,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "contracts",
       "dependencies": {
+        "@archethicjs/multisig-sdk": "^1.0.10",
         "@archethicjs/sdk": "^1.20.1",
         "yargs": "^17.7.2"
       }
@@ -26,10 +26,18 @@
         "phoenix": "^1.4.0"
       }
     },
+    "node_modules/@archethicjs/multisig-sdk": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@archethicjs/multisig-sdk/-/multisig-sdk-1.0.10.tgz",
+      "integrity": "sha512-uvV0jWhsXZpVsu1snA5ngSS8M5/UF76P0kHA5QSWObOJZlIFj/fU8XD2h9rpsgGgsO+OT2ypDqZjpaRDwTolig==",
+      "dependencies": {
+        "@archethicjs/sdk": "^1.21.2"
+      }
+    },
     "node_modules/@archethicjs/sdk": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/@archethicjs/sdk/-/sdk-1.20.1.tgz",
-      "integrity": "sha512-wIk9X6HOFPVGJ/+Kn5oTQHEGrHMLRIAvzBhQEjyfjYCv56Rl78lqJ+bC1mxXJZDUyAlozH/+dIJXXVWAEjVVKA==",
+      "version": "1.21.3",
+      "resolved": "https://registry.npmjs.org/@archethicjs/sdk/-/sdk-1.21.3.tgz",
+      "integrity": "sha512-betGzCwvPsmgpidcYYOu3+sH8zPN78NwKm8blqRtlEhFjDbgU5iwNtOMNUXa3d07x2nL+tFblUlmYigDAPaOAg==",
       "dependencies": {
         "@absinthe/socket": "^0.2.1",
         "blakejs": "^1.2.1",
@@ -39,6 +47,7 @@
         "curve25519-js": "^0.0.4",
         "ed2curve": "^0.3.0",
         "elliptic": "^6.5.4",
+        "fast-check": "^3.19.0",
         "isomorphic-ws": "^5.0.0",
         "js-sha3": "^0.9.0",
         "json-rpc-2.0": "^1.6.0",
@@ -289,6 +298,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/fast-check": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.1.tgz",
+      "integrity": "sha512-u/MudsoQEgBUZgR5N1v87vEgybeVYus9VnDVaIkxkkGP2jt54naghQ3PCQHJiogS8U/GavZCUPFfx3Xkp+NaHw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
@@ -425,6 +455,21 @@
       "version": "1.7.9",
       "resolved": "https://registry.npmjs.org/phoenix/-/phoenix-1.7.9.tgz",
       "integrity": "sha512-oHBka/WCKVtFHNCCqnVDxiSHQZ0vvV0pU1I4oBmm68rNvGH3lVjdNGLRhK0+c3zcfsrqgpRS2p+Et6N4QAd2LQ=="
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
     },
     "node_modules/regenerator-runtime": {
       "version": "0.12.1",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@archethicjs/multisig-sdk": "^1.0.10",
     "@archethicjs/sdk": "^1.20.1",
     "yargs": "^17.7.2"
   },


### PR DESCRIPTION
This PR supports multisig for bridge contracts management.
It adds two commands:
- `deploy_multisig`: convert the master chain into a multisig
- `get_router_address`: to get the address of the router from the keychain service derivations

To test this PR:

- Init the keychain: `node dex init_keychain`
- Deploy the factory: `node dex deploy_factory`
- Change the master to multisig: `node dex deploy_multisig`
- Get the router address: `node dex get_router_address`
- Fund this address (either via multisig or faucet)
- Deploy the router without the initial funding: `node dex deploy_router --without_funding`
- To update the pool with multisig: `node dex update_router --with_multisig`
- Confirm the multisig transaction
   - Through the [UI](https://github.com/archethic-foundation/multisig/tree/main/packages/app)
   - Using the [CLI](https://github.com/archethic-foundation/multisig/tree/main/packages/cli):  node multisig.js confirm-transaction

Others update commands have been updated as:
- `update_protocol_fee`
- `update_pools`
- `update_lp_fee`
- `update_farms`
- `update_farm_dates`